### PR TITLE
Correction crash potentiel

### DIFF
--- a/src/partner.ts
+++ b/src/partner.ts
@@ -62,9 +62,8 @@ export abstract class Partenaire extends Base {
                     headers,
                 }
                 return fetch(url, config).then(r => {
-                    if (r.ok) {
-                        return r.json()
-                    }
+                    if (r.status === 204) { return { resultats: [] }; }
+                    else if (r.ok) { return r.json() }
                     throw new Error(r.statusText)
                 })
 


### PR DESCRIPTION
Quand il y a un status 204, le module jete une erreur, pourtant la réponse indique un résultat positif même si le retour de requête est vide. Avec cette correction, plus d'erreur inutile.